### PR TITLE
Entidade de Categoria

### DIFF
--- a/src/main/java/br/com/alura/edigi/model/Category.java
+++ b/src/main/java/br/com/alura/edigi/model/Category.java
@@ -1,0 +1,44 @@
+package br.com.alura.edigi.model;
+
+import java.time.LocalDateTime;
+
+public class Category {
+
+    private String name;
+    private LocalDateTime createdAt;
+
+    public Category(String name) {
+       setName(name); 
+       this.createdAt = LocalDateTime.now();
+    }
+
+    private void setName(String name) {
+        if(name == null || name.isEmpty())
+            throw new IllegalArgumentException("O name da categoria não pode ser vazio");
+
+        this.name = name;
+    }
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + name.hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+        if(this == obj) return true;
+        if(this.getClass() != obj.getClass()) return false;
+
+        Category comparado = (Category) obj;
+        return this.name.equals(comparado.name);
+	}
+
+    @Override
+    public String toString() {
+        return "Category [name=" + name + "]";
+    }
+
+}

--- a/src/main/java/br/com/alura/edigi/model/Category.java
+++ b/src/main/java/br/com/alura/edigi/model/Category.java
@@ -14,7 +14,7 @@ public class Category {
 
     private void setName(String name) {
         if(name == null || name.isEmpty())
-            throw new IllegalArgumentException("O name da categoria não pode ser vazio");
+            throw new IllegalArgumentException("O nome da categoria não pode ser vazio");
 
         this.name = name;
     }

--- a/src/main/java/br/com/alura/edigi/repository/AuthorRepository.java
+++ b/src/main/java/br/com/alura/edigi/repository/AuthorRepository.java
@@ -1,4 +1,4 @@
-package br.com.alura.edigi.repositories;
+package br.com.alura.edigi.repository;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/br/com/alura/edigi/repository/CategoryRepository.java
+++ b/src/main/java/br/com/alura/edigi/repository/CategoryRepository.java
@@ -1,0 +1,20 @@
+package br.com.alura.edigi.repository;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import br.com.alura.edigi.model.Category;
+
+public class CategoryRepository {
+
+    private static Set<Category> categories = new HashSet<>();
+
+    public void save(Category category){
+        if( !(CategoryRepository.categories.add(category)) ){
+            throw new IllegalArgumentException("Já existe uma categoria cadastrada com esse nome");
+        }
+
+    }
+
+
+}

--- a/src/test/java/br/com/alura/edigi/models/CategoryTest.java
+++ b/src/test/java/br/com/alura/edigi/models/CategoryTest.java
@@ -9,15 +9,15 @@ public class CategoryTest {
         try {
             System.out.println("Testando a exceção de nome nulo para a categoria");
             new Category(null);
-        } catch (IllegalArgumentException e) {
-            System.out.println(e.getMessage() + "\n");
+        } catch (IllegalArgumentException error) {
+            System.out.println(error.getMessage() + "\n");
         }
 
         try {
             System.out.println("Testando a exceção de nome vazio para a categoria");
             new Category("");
-        } catch (Exception e) {
-            System.out.println(e.getMessage() + "\n");
+        } catch (IllegalArgumentException error) {
+            System.out.println(error.getMessage() + "\n");
         }
     }
 }

--- a/src/test/java/br/com/alura/edigi/models/CategoryTest.java
+++ b/src/test/java/br/com/alura/edigi/models/CategoryTest.java
@@ -1,0 +1,23 @@
+package br.com.alura.edigi.models;
+
+import br.com.alura.edigi.model.Category;
+
+public class CategoryTest {
+
+    public static void main(String[] args) {
+        
+        try {
+            System.out.println("Testando a exceção de nome nulo para a categoria");
+            new Category(null);
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getMessage() + "\n");
+        }
+
+        try {
+            System.out.println("Testando a exceção de nome vazio para a categoria");
+            new Category("");
+        } catch (Exception e) {
+            System.out.println(e.getMessage() + "\n");
+        }
+    }
+}

--- a/src/test/java/br/com/alura/edigi/respository/AuthorRepositoryTest.java
+++ b/src/test/java/br/com/alura/edigi/respository/AuthorRepositoryTest.java
@@ -1,6 +1,7 @@
-package br.com.alura.edigi.repositories;
+package br.com.alura.edigi.respository;
 
 import br.com.alura.edigi.model.Author;
+import br.com.alura.edigi.repository.AuthorRepository;
 
 public class AuthorRepositoryTest {
     public static void main(String[] args) {

--- a/src/test/java/br/com/alura/edigi/respository/CategoryRepositoryTest.java
+++ b/src/test/java/br/com/alura/edigi/respository/CategoryRepositoryTest.java
@@ -1,0 +1,31 @@
+package br.com.alura.edigi.respository;
+
+import br.com.alura.edigi.model.Category;
+import br.com.alura.edigi.repository.CategoryRepository;
+
+public class CategoryRepositoryTest {
+
+    public static void main(String[] args) {
+        CategoryRepository categoryRepository = new CategoryRepository();
+        
+        try {
+            System.out.println("Cadastro correto de uma categoria retornando a mensagem de suecesso");
+            Category java = new Category("Java");
+            categoryRepository.save(java);
+            System.out.println("Categoria cadastrada com sucesso");
+            System.out.println(java);
+
+        } catch (IllegalArgumentException error) {
+            System.out.println(error.getMessage() + "\n");
+        }
+
+        System.out.println();
+
+        try {
+            System.out.println("Testando a exceção de categoria repetida");
+            categoryRepository.save(new Category("Java"));
+        } catch (IllegalArgumentException error) {
+            System.out.println(error.getMessage() + "\n");
+        }
+    }
+}


### PR DESCRIPTION
Voltei para `repository` então, eu tinha ficado um pouco reflexivo por se tratar de vários repositórios, mas eu também utilizo `model` quando pela mesma lógica deveria ser `models`, então acredito que é mais consistente deixar `repository`

